### PR TITLE
Add diagnostic for "ValueError: max() arg is an empty sequence" error

### DIFF
--- a/cmake_min_version.py
+++ b/cmake_min_version.py
@@ -79,7 +79,7 @@ def binary_search(cmake_parameters: List[str], tools_dir: str) -> Optional[CMake
     versions = get_cmake_binaries(tools_dir)  # type: List[CMakeBinary]
     cmake_versions = [len(cmake.version) for cmake in versions]
     if len(cmake_versions) == 0:
-        print(colored('Error: No cmake versions found in the tool dir. Make sure to run the cmake_downloader script first.', 'red'))
+        print(colored('Error: No CMake versions found in the tool dir. Make sure to run the cmake_downloader script first.', 'red'))
         sys.exit(1)
     longest_version_string = max(cmake_versions) + 1  # type: int
 

--- a/cmake_min_version.py
+++ b/cmake_min_version.py
@@ -7,6 +7,7 @@ import math
 import os.path
 import re
 import subprocess
+import sys
 import tempfile
 from typing import List, Optional, NamedTuple
 
@@ -76,7 +77,11 @@ def try_configure(binary: str, cmake_parameters: List[str]) -> ConfigureResult:
 
 def binary_search(cmake_parameters: List[str], tools_dir: str) -> Optional[CMakeBinary]:
     versions = get_cmake_binaries(tools_dir)  # type: List[CMakeBinary]
-    longest_version_string = max([len(cmake.version) for cmake in versions]) + 1  # type: int
+    cmake_versions = [len(cmake.version) for cmake in versions]
+    if len(cmake_versions) == 0:
+        print(colored('Error: No cmake versions found in the tool dir. Make sure to run the cmake_downloader script first.', 'red'))
+        sys.exit(1)
+    longest_version_string = max(cmake_versions) + 1  # type: int
 
     lower_idx = 0  # type: int
     upper_idx = len(versions) - 1  # type: int


### PR DESCRIPTION
If you run the script without first downloading cmake versions you get the following error:

```
› venv/bin/python cmake_min_version.py ~/path/to/project
Found 0 CMake binaries from directory tools

Traceback (most recent call last):
  File "<path>/cmake_min_version/cmake_min_version.py", line 162, in <module>
    working_version = binary_search(args.params, args.tools_directory)
  File "<path>/cmake_min_version/cmake_min_version.py", line 79, in binary_search
    longest_version_string = max([len(cmake.version) for cmake in versions]) + 1  # type: int
ValueError: max() arg is an empty sequence
```

This PR just adds a quick error to tell the user what to do.