### PR TITLE
Add --min_version and --max_version parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,25 @@ venv/bin/pip3 install -r requirements.txt
 The script [`cmake_downloader.py`](cmake_downloader.py) takes care of downloading CMake binaries:
 
 ```sh
-usage: cmake_downloader.py [-h] [--os {macos,linux}] [--latest_release]
+usage: cmake_downloader.py [-h] [--os {macos,linux,windows}] [--latest_release]
                            [--latest_patch] [--first_minor]
-                           [--release_candidates] [--tools_directory DIR]
+                           [--release_candidates] [--min_version MIN_VERSION]
+                           [--max_version MAX_VERSION] [--tools_directory DIR]
 
 Download CMake binaries.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --os {macos,linux}    OS to download CMake for (default: macos)
+  --os {macos,linux,windows}
+                        OS to download CMake for (default: linux)
   --latest_release      only download the latest release (default: False)
-  --latest_patch        only download the latest patch version for each
-                        release (default: False)
-  --first_minor         only download the first minor version for each release
-                        (default: False)
+  --latest_patch        only download the latest patch version for each release (default: False)
+  --first_minor         only download the first minor version for each release (default: False)
   --release_candidates  also consider release candidates (default: False)
+  --min_version MIN_VERSION
+                        only download versions greater or equal than MIN_VERSION
+  --max_version MAX_VERSION
+                        only download versions less or equal than MAX_VERSION
   --tools_directory DIR
                         path to the CMake binaries (default: "tools")
 ```

--- a/cmake_downloader.py
+++ b/cmake_downloader.py
@@ -99,10 +99,10 @@ if __name__ == '__main__':
                         help='only download the first minor version for each release (default: False)')
     parser.add_argument('--release_candidates', action='store_true',
                         help='also consider release candidates (default: False)')
-    parser.add_argument('--tools_directory', metavar='DIR', default='tools',
-                        help='path to the CMake binaries (default: "tools")')
     parser.add_argument('--min_version', help='only download versions greater or equal than MIN_VERSION')
     parser.add_argument('--max_version', help='only download versions less or equal than MAX_VERSION')
+    parser.add_argument('--tools_directory', metavar='DIR', default='tools',
+                        help='path to the CMake binaries (default: "tools")')
     args = parser.parse_args()
 
     version_dict = create_version_dict(os=args.os)

--- a/cmake_downloader.py
+++ b/cmake_downloader.py
@@ -101,11 +101,19 @@ if __name__ == '__main__':
                         help='also consider release candidates (default: False)')
     parser.add_argument('--tools_directory', metavar='DIR', default='tools',
                         help='path to the CMake binaries (default: "tools")')
+    parser.add_argument('--min_version', help='only download versions greater or equal than MIN_VERSION')
+    parser.add_argument('--max_version', help='only download versions less or equal than MAX_VERSION')
     args = parser.parse_args()
 
     version_dict = create_version_dict(os=args.os)
     versions = sorted([version_parse(version) for version in version_dict.keys()])
     print(f'Found {len(versions)} versions from {versions[0]} to {versions[-1]}.')
+
+    if args.min_version:
+        versions = sorted([version for version in versions if version >= version_parse(args.min_version)])
+
+    if args.max_version:
+        versions = sorted([version for version in versions if version <= version_parse(args.max_version)])
 
     if not args.release_candidates:
         versions = [version for version in versions if not version.is_prerelease]


### PR DESCRIPTION
With the growing list of available CMake versions, downloading the binaries starts to take a huge time and a lot of disk space even when `--latest_patch` or `--first_minor` are used (eg. latest patches from CMake 3.1 to 3.27 take more than 3GB of space).

`--min_version` and `--max_version` filter arguments can help to reduce the number of CMake binaries downloaded when an absolute minimum or maximum versions are known.

As an example, I usually only supports CMake versions as old as the one distributed with the oldest supported Ubuntu LTS (ESM period not considered). Currently, Ubuntu 18.04 (which reached end of standard support last June 2023) ships CMake 3.10. So using `--min_version 3.10` I can skip the download of almost ten binaries :wink: