### PR TITLE
Fix relative paths

### DIFF
--- a/cmake_downloader.py
+++ b/cmake_downloader.py
@@ -13,6 +13,7 @@ import requests
 from packaging.version import parse as version_parse
 from tqdm import tqdm
 
+SCRIPT_DIR = Path(__file__).resolve().parent
 TIMEOUT_SECONDS = 10
 session = requests.Session()
 
@@ -138,7 +139,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tools_directory",
         metavar="DIR",
-        default="tools",
+        default=SCRIPT_DIR / "tools",
+        type=Path,
         help='path to the CMake binaries (default: "tools")',
     )
     args = parser.parse_args()
@@ -173,4 +175,4 @@ if __name__ == "__main__":
 
     for idx, version in enumerate(versions):
         print(f"Downloading CMake {version.public} ({idx+1}/{len(versions)})...")
-        download_and_extract(url=version_dict[version.public], path=Path(args.tools_directory))
+        download_and_extract(url=version_dict[version.public], path=args.tools_directory)

--- a/cmake_min_version.py
+++ b/cmake_min_version.py
@@ -13,8 +13,8 @@ from time import time
 from typing import List, NamedTuple, Optional
 
 from packaging.version import parse as version_parse
+from pathvalidate import ValidationError, validate_filepath
 from termcolor import colored
-from pathvalidate import validate_filepath, ValidationError
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 

--- a/cmake_min_version.py
+++ b/cmake_min_version.py
@@ -16,6 +16,8 @@ from packaging.version import parse as version_parse
 from termcolor import colored
 from pathvalidate import validate_filepath, ValidationError
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+
 
 class CMakeBinary(NamedTuple):
     version: str
@@ -190,7 +192,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tools_directory",
         metavar="DIR",
-        default="tools",
+        default=SCRIPT_DIR / "tools",
+        type=Path,
         help='path to the CMake binaries (default: "tools")',
     )
     parser.add_argument(
@@ -210,13 +213,13 @@ if __name__ == "__main__":
     if args.full_search:
         working_version = full_search(
             cmake_parameters=args.params,
-            tools_dir=Path(args.tools_directory),
+            tools_dir=args.tools_directory,
             error_output=args.error_details,
         )
     else:
         working_version = binary_search(
             cmake_parameters=args.params,
-            tools_dir=Path(args.tools_directory),
+            tools_dir=args.tools_directory,
             error_output=args.error_details,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tqdm==4.66.2
 requests==2.31.0
 packaging==24.0
 termcolor==2.3.0  # 2.4.0 breaks Python 3.7 support
+pathvalidate==3.2.1


### PR DESCRIPTION
- We're using `cwd=tmpdir.name` in `try_configure()` for higher compatibility because ` -B <path-to-build>` was added in CMake version 3.13. This however leads to unexpected results when we pass relative paths as arguments because such paths become relative to the temporary directory, not cwd of shell.
- `tools_directory` containing CMake downloaded binaries is by default created relatively to current working directory instead of being placed in the root directory of the repository which would make more sense.

Thanks to the proposed changes the following call becomes possible:
```shell
❯ cd ~/projects
❯ ~/cmake_min_version/cmake_min_version.py example
``` 